### PR TITLE
Fix reached bug in dfs

### DIFF
--- a/Lecture.13/dfs.cpp
+++ b/Lecture.13/dfs.cpp
@@ -19,8 +19,6 @@ void recursive_dfs(const Digraph& graph, const int u, const int prev, unordered_
 }
 
 void dfs(const Digraph& graph, const int start, unordered_set<int> & reached) {
-	reached.insert(start);
-
 	stack<int> unexplored;
 	unexplored.push(start);
 


### PR DESCRIPTION
A bug is caused by inserting `start` immediately to `reached` which causes the while loop exit before doing a depth first search due to condition `if (reached.find(u) != reached.end())`. This bug was discovered during office hours.